### PR TITLE
add Debian OVAL sources

### DIFF
--- a/oval_sources.json
+++ b/oval_sources.json
@@ -12,5 +12,8 @@
 	"rhel_07": "https://www.redhat.com/security/data/oval/com.redhat.rhsa-RHEL7.xml.bz2",
 	"rhel_08": "https://www.redhat.com/security/data/oval/com.redhat.rhsa-RHEL8.xml.bz2",
 	"rhel_09": "https://www.redhat.com/security/data/oval/com.redhat.rhsa-RHEL9.xml.bz2",
-	"amzn_02": "https://www.redhat.com/security/data/oval/com.redhat.rhsa-RHEL7.xml.bz2"
+	"amzn_02": "https://www.redhat.com/security/data/oval/com.redhat.rhsa-RHEL7.xml.bz2",
+	"debian_9": "https://www.debian.org/security/oval/oval-definitions-stretch.xml.bz2",
+	"debian_10": "https://www.debian.org/security/oval/oval-definitions-buster.xml.bz2",
+	"debian_11": "https://www.debian.org/security/oval/oval-definitions-bullseye.xml.bz2"
 }

--- a/oval_sources.json
+++ b/oval_sources.json
@@ -6,11 +6,11 @@
 	"ubuntu_2104": "https://security-metadata.canonical.com/oval/com.ubuntu.hirsute.usn.oval.xml.bz2",
 	"ubuntu_2110": "https://security-metadata.canonical.com/oval/com.ubuntu.impish.usn.oval.xml.bz2",
 	"ubuntu_2204": "https://security-metadata.canonical.com/oval/com.ubuntu.jammy.usn.oval.xml.bz2",
-  "ubuntu_2304": "https://security-metadata.canonical.com/oval/com.ubuntu.lunar.usn.oval.xml.bz2",
+	"ubuntu_2304": "https://security-metadata.canonical.com/oval/com.ubuntu.lunar.usn.oval.xml.bz2",
 	"debian_9": "https://www.debian.org/security/oval/oval-definitions-stretch.xml.bz2",
 	"debian_10": "https://www.debian.org/security/oval/oval-definitions-buster.xml.bz2",
-	"debian_11": "https://www.debian.org/security/oval/oval-definitions-bullseye.xml.bz2"
-	"debian_12": "https://www.debian.org/security/oval/oval-definitions-bookworm.xml.bz2"
+	"debian_11": "https://www.debian.org/security/oval/oval-definitions-bullseye.xml.bz2",
+	"debian_12": "https://www.debian.org/security/oval/oval-definitions-bookworm.xml.bz2",
 	"rhel_06": "https://www.redhat.com/security/data/oval/v2/RHEL6/rhel-6.oval.xml.bz2",
 	"rhel_07": "https://www.redhat.com/security/data/oval/v2/RHEL7/rhel-7.oval.xml.bz2",
 	"rhel_08": "https://www.redhat.com/security/data/oval/v2/RHEL8/rhel-8.oval.xml.bz2",


### PR DESCRIPTION
Get OVAL definitions for Debian to enable Vulnerability Processing.