### PR TITLE
Add NVD_API_KEY to environment

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -41,6 +41,7 @@ jobs:
           command: |
             cd fleet
             go mod download
+            export NVD_API_KEY=${{ secrets.NVD_API_KEY }}
             export NETWORK_TEST_GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
             go run -tags fts5 cmd/cpe/generate.go
             go run -tags fts5 cmd/msrc/generate.go


### PR DESCRIPTION
Before merging, we need to put NVD_API_KEY into secrets. @lukeheath Who can update secrets?

https://nvd.nist.gov/developers/request-an-api-key

This is part of the fix for https://github.com/fleetdm/fleet/issues/14887

Manually tested (with corresponding fleetdm/fleet changes) in my personal fork: https://github.com/getvictor/nvd/releases