### PR TITLE
Increased `generate` timeout to 30 minutes.

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Generate security artifacts
         uses: nick-fields/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd # v2.8.3
         with:
-          timeout_minutes: 15
+          timeout_minutes: 30
           max_attempts: 3
           retry_wait_seconds: 120
           command: |


### PR DESCRIPTION
The CPE generation step takes ~15 minutes by itself, due to the recommended 6 second wait time between API requests. So, doubling timeout.