### PR TITLE
Clean up set-output warning.

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Current date
         id: date
         run: |
-          echo "::set-output name=date::$(date +'%Y%m%d%H%M')"
+          echo "date=$(date +'%Y%m%d%H%M')" >> $GITHUB_OUTPUT
 
       # Note that a new commit must be made for each release, otherwise GitHub does not order
       # the releases properly.


### PR DESCRIPTION
Clean up set-output deprecation warning as described here: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

A similar change was done/tested here: https://github.com/getvictor/nvd-cve/blob/c954275c5ea485f5f4bdf9e9190ac997f6f7017a/.github/workflows/generate.yml#L50