### PR TITLE
Increase timeout to 100 minutes

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Generate security artifacts
         uses: nick-fields/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd # v2.8.3
         with:
-          timeout_minutes: 30
+          timeout_minutes: 100
           max_attempts: 3
           retry_wait_seconds: 120
           command: |


### PR DESCRIPTION
Increasing to 100 minutes to make sure we can account for a slow responding NVD 2.0 service.

Failure: https://github.com/fleetdm/nvd/actions/runs/6963998392/job/18962586182

A few samples that show that each request could take from ~30s-~1m (with 10k results each we need 120 requests):
```
time=2023-11-23T10:40:15.203Z level=INFO msg="Fetching index 50000 out of 1199455"
time=2023-11-23T10:40:37.749Z level=INFO msg="Got 10000 results"
time=2023-11-23T10:40:43.789Z level=INFO msg="Fetching index 60000 out of 1199455"
time=2023-11-23T10:41:09.883Z level=INFO msg="Got 10000 results"
time=2023-11-23T10:41:15.897Z level=INFO msg="Fetching index 70000 out of 1199455"
time=2023-11-23T10:41:35.628Z level=INFO msg="Got 10000 results"
time=2023-11-23T10:41:41.643Z level=INFO msg="Fetching index 80000 out of 1199455"
time=2023-11-23T10:42:41.193Z level=INFO msg="Got 10000 results"
time=2023-11-23T10:42:47.203Z level=INFO msg="Fetching index 90000 out of 1199455"
time=2023-11-23T10:43:12.114Z level=INFO msg="Got 10000 results"
```