### PR TITLE
Drop Amazon Linux 2 from OVAL list

### DIFF
--- a/oval_sources.json
+++ b/oval_sources.json
@@ -17,6 +17,5 @@
 	"rhel_06": "https://www.redhat.com/security/data/oval/v2/RHEL6/rhel-6.oval.xml.bz2",
 	"rhel_07": "https://www.redhat.com/security/data/oval/v2/RHEL7/rhel-7.oval.xml.bz2",
 	"rhel_08": "https://www.redhat.com/security/data/oval/v2/RHEL8/rhel-8.oval.xml.bz2",
-	"rhel_09": "https://www.redhat.com/security/data/oval/v2/RHEL9/rhel-9.oval.xml.bz2",
-	"amzn_02": "https://www.redhat.com/security/data/oval/v2/RHEL7/rhel-7.oval.xml.bz2"
+	"rhel_09": "https://www.redhat.com/security/data/oval/v2/RHEL9/rhel-9.oval.xml.bz2"
 }


### PR DESCRIPTION
fleetdem/fleet#20934

We're pointing at the wrong source here, and are creating false positive alerts as a result.