### PR TITLE
Added clean flag to run MSRC feed from scratch

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -7,15 +7,16 @@ on:
   workflow_dispatch: # Manual
     inputs:
       clean:
-        description: 'Download fresh feeds from MSRC. Any value other than "false" will trigger a clean download'
+        description: 'Clean: download all feeds from MSRC from scratch.'
         required: true
-        default: 'false'
+        type: boolean
+        default: false
 
 permissions:
   contents: write
 
 env:
-  MSRC_CLEAN: ${{ github.event.inputs.clean || 'false' }}
+  MSRC_CLEAN: ${{ github.event.inputs.clean }}
 
 jobs:
   security_artifacts:

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -5,9 +5,17 @@ on:
   schedule:
     - cron: "0 0 * * *"
   workflow_dispatch: # Manual
+    inputs:
+      clean:
+        description: 'Download fresh feeds from MSRC. Any value other than "false" will trigger a clean download'
+        required: true
+        default: 'false'
 
 permissions:
   contents: write
+
+env:
+  MSRC_CLEAN: ${{ github.event.inputs.clean || 'false' }}
 
 jobs:
   security_artifacts:


### PR DESCRIPTION
This PR is related to [This PR](https://github.com/fleetdm/fleet/pull/31851) addressing [#31474](https://github.com/fleetdm/fleet/issues/31474). 

Added a manual clean flag for running the MSRC feed from scratch.

I tested this change:
- Ran generate.yml with clean = 'true' and tested the released file is correct.
- Ran generate.yml with clean = 'false' and tested the released file is still wrong.

But I had to manually remove and change a lot of the file to make it work on my fork.
For example: remove `export NVD_API_KEY=${{ secrets.NVD_API_KEY }}` and edit `repository: fleetdm/fleet` to my fork.

**This change needs QA before it can be merged.**