### PR TITLE
Add Ubuntu 26.04 (Resolute Raccoon) OVAL source

### DIFF
--- a/oval_sources.json
+++ b/oval_sources.json
@@ -10,6 +10,7 @@
 	"ubuntu_2404": "https://security-metadata.canonical.com/oval/com.ubuntu.noble.usn.oval.xml.bz2",
 	"ubuntu_2410": "https://security-metadata.canonical.com/oval/com.ubuntu.oracular.usn.oval.xml.bz2",
 	"ubuntu_2504": "https://security-metadata.canonical.com/oval/com.ubuntu.plucky.usn.oval.xml.bz2",
+	"ubuntu_2604": "https://security-metadata.canonical.com/oval/com.ubuntu.resolute.usn.oval.xml.bz2",
 	"debian_9": "https://www.debian.org/security/oval/oval-definitions-stretch.xml.bz2",
 	"debian_10": "https://www.debian.org/security/oval/oval-definitions-buster.xml.bz2",
 	"debian_11": "https://www.debian.org/security/oval/oval-definitions-bullseye.xml.bz2",


### PR DESCRIPTION
## Summary
- Add `ubuntu_2604` entry to `oval_sources.json` pointing to Canonical's OVAL feed for Ubuntu 26.04 LTS (Resolute Raccoon).

Refs https://github.com/fleetdm/fleet/issues/45748

## Test plan
- [x] Verified `https://security-metadata.canonical.com/oval/com.ubuntu.resolute.usn.oval.xml.bz2` returns HTTP 200 with `application/x-bzip2` content.
- [x] CI passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)